### PR TITLE
feat: support package.json linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,32 @@ export default [
 ];
 ```
 
+### With `package.json`
+
+Some rules (e.g. `ban-dependencies`) can be used against your `package.json`.
+
+You can achieve this by using `jsonc-eslint-parser`.
+
+For example, in your `.eslintrc.json`:
+
+```json
+{
+  "overrides": [
+    {
+      "files": ["package.json"],
+      "parser": "jsonc-eslint-parser",
+      "plugins": ["depend"],
+      "rules": {
+        "depend/ban-dependencies": "error"
+      }
+    }
+  ]
+}
+```
+
+Read more at the
+[`jsonc-eslint-parser` docs](https://github.com/ota-meshi/jsonc-eslint-parser).
+
 ## Rules
 
 - [`depend/ban-dependencies`](./docs/rules/ban-dependencies.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "eslint": "^8.56.0",
         "eslint-config-google": "^0.14.0",
         "eslint-plugin-eslint-plugin": "^5.3.0",
+        "jsonc-eslint-parser": "^2.4.0",
         "prettier": "^3.2.5",
         "rimraf": "^5.0.5",
         "typescript": "^5.3.3",
@@ -1535,6 +1536,24 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/jsonc-eslint-parser": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.0.tgz",
+      "integrity": "sha512-WYDyuc/uFcGp6YtM2H0uKmUwieOuzeE/5YocFJLnLfclZ4inf3mRn8ZVy1s7Hxji7Jxm6Ss8gqpexD/GlKoGgg==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.5.0",
+        "eslint-visitor-keys": "^3.0.0",
+        "espree": "^9.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint": "^8.56.0",
     "eslint-config-google": "^0.14.0",
     "eslint-plugin-eslint-plugin": "^5.3.0",
+    "jsonc-eslint-parser": "^2.4.0",
     "prettier": "^3.2.5",
     "rimraf": "^5.0.5",
     "typescript": "^5.3.3",

--- a/src/test/rules/ban-dependencies_test.ts
+++ b/src/test/rules/ban-dependencies_test.ts
@@ -10,6 +10,7 @@ const ruleTester = new RuleTester({
 });
 
 const tseslintParser = require.resolve('@typescript-eslint/parser');
+const jsonParser = require.resolve('jsonc-eslint-parser');
 
 ruleTester.run('ban-dependencies', rule, {
   valid: [
@@ -43,6 +44,33 @@ ruleTester.run('ban-dependencies', rule, {
           presets: []
         }
       ]
+    },
+    {
+      code: `{
+        "dependencies": {
+          "unknown-module": "^1.0.0"
+        }
+      }`,
+      filename: 'package.json',
+      parser: jsonParser
+    },
+    {
+      code: `{
+        "dependencies": {
+          "npm-run-all": "^1.0.0"
+        }
+      }`,
+      filename: 'not-a-package.json',
+      parser: jsonParser
+    },
+    {
+      code: `{
+        "not-dependencies": {
+          "some-other-nonsense": 123
+        }
+      }`,
+      filename: 'package.json',
+      parser: jsonParser
     }
   ],
 
@@ -147,6 +175,26 @@ ruleTester.run('ban-dependencies', rule, {
           messageId: 'noneReplacement',
           data: {
             name: 'oogabooga'
+          }
+        }
+      ]
+    },
+    {
+      code: `{
+        "dependencies": {
+          "npm-run-all": "^1.0.0"
+        }
+      }`,
+      filename: 'package.json',
+      parser: jsonParser,
+      errors: [
+        {
+          line: 3,
+          column: 11,
+          messageId: 'documentedReplacement',
+          data: {
+            name: 'npm-run-all',
+            url: getReplacementsDocUrl('npm-run-all')
           }
         }
       ]


### PR DESCRIPTION
This adds support for using `jsonc-eslint-parser` against your `package.json` to the ban-dependencies rule.