### PR TITLE
feat: add is-builtin-module

### DIFF
--- a/src/replacements.ts
+++ b/src/replacements.ts
@@ -35,6 +35,16 @@ export const preferredReplacements: Replacement[] = [
     type: 'documented',
     moduleName: 'npm-run-all',
     docPath: 'npm-run-all'
+  },
+  {
+    type: 'documented',
+    moduleName: 'is-builtin-module',
+    docPath: 'is-builtin-module'
+  },
+  {
+    type: 'documented',
+    moduleName: 'builtin-modules',
+    docPath: 'is-builtin-module'
   }
 ];
 


### PR DESCRIPTION
Adds a documented replacement for `is-builtin-module`.

It is still useful in runtimes which have no `node:module` module available, though few enough cases we can rely on consumers using lint ignores.