### PR TITLE
Fix broken link

### DIFF
--- a/src/test/util/rule-meta_test.ts
+++ b/src/test/util/rule-meta_test.ts
@@ -10,7 +10,7 @@ test('getDocsUrl', async (t) => {
   await t.test('gets the url of a given rule doc', () => {
     assert.equal(
       getDocsUrl('bloop'),
-      'https://github.com/43081j/eslint-plugin-assert/blob/main/docs/rules/bloop.md'
+      'https://github.com/es-tooling/eslint-plugin-depend/blob/main/docs/rules/bloop.md'
     );
   });
 });

--- a/src/util/rule-meta.ts
+++ b/src/util/rule-meta.ts
@@ -4,7 +4,7 @@
  * @return {string}
  */
 export function getDocsUrl(name: string): string {
-  return `https://github.com/43081j/eslint-plugin-assert/blob/main/docs/rules/${name}.md`;
+  return `https://github.com/es-tooling/module-replacements/blob/main/docs/modules/${name}.md`;
 }
 
 /**

--- a/src/util/rule-meta.ts
+++ b/src/util/rule-meta.ts
@@ -4,7 +4,7 @@
  * @return {string}
  */
 export function getDocsUrl(name: string): string {
-  return `https://github.com/es-tooling/module-replacements/blob/main/docs/modules/${name}.md`;
+  return `https://github.com/es-tooling/eslint-plugin-depend/blob/main/docs/rules/${name}.md`;
 }
 
 /**


### PR DESCRIPTION
The URLs generated by `getDocsURL()` are currently 404ing

I found another repo that may have the details