### PR TITLE
feat: support flat configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Or if you're using (flat) config files, add to your `eslint.config.js`:
 import {configs} from 'eslint-plugin-depend';
 
 export default [
-  configs.recommended,
+  configs['flat/recommended'],
 
   // or if you want to specify `files`, or other options
   {
-    ...configs.recommended,
+    ...configs['flat/recommended'],
     files: ['test/**/*.js']
   }
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,6 +13,7 @@ module.exports = [
     rules: {
       'comma-dangle': ['error', 'never'],
       'indent': 'off',
+      'quote-props': 'off',
       'max-len': ['error', {
         ignoreTemplateLiterals: true,
         ignoreStrings: true

--- a/src/configs/legacy-recommended.ts
+++ b/src/configs/legacy-recommended.ts
@@ -1,0 +1,8 @@
+import type {ESLint} from 'eslint';
+
+export const config: ESLint.ConfigData = {
+  plugins: ['depend'],
+  rules: {
+    'depend/ban-dependencies': 'error'
+  }
+};

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -1,4 +1,11 @@
-export const recommended = {
-  plugins: ['depend'],
-  rules: {}
-};
+import type {ESLint, Linter} from 'eslint';
+
+export const configFactory = (plugin: ESLint.Plugin): Linter.FlatConfig => ({
+  plugins: {
+    depend: plugin
+  },
+
+  rules: {
+    'depend/ban-dependencies': 'error'
+  }
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,15 @@
-import {recommended} from './configs/recommended.js';
+import type {Rule, ESLint} from 'eslint';
+import {configFactory as configRecommended} from './configs/recommended.js';
+import {config as configLegacyRecommended} from './configs/legacy-recommended.js';
 import {rule as banDependencies} from './rules/ban-dependencies.js';
 
-export const configs = {
-  recommended
+export const rules: Record<string, Rule.RuleModule> = {
+  'ban-dependencies': banDependencies
 };
 
-export const rules = {
-  'ban-dependencies': banDependencies
+const plugin: ESLint.Plugin = {rules};
+
+export const configs = {
+  recommended: configLegacyRecommended,
+  'flat/recommended': configRecommended(plugin)
 };

--- a/src/test/configs_test.ts
+++ b/src/test/configs_test.ts
@@ -1,0 +1,19 @@
+import type {ESLint, Linter} from 'eslint';
+import * as assert from 'node:assert/strict';
+import {test} from 'node:test';
+import {configs} from '../main.js';
+
+type ConfigLike = Linter.FlatConfig | ESLint.ConfigData;
+
+const isFlatConfig = (config: ConfigLike): config is Linter.FlatConfig =>
+  !Array.isArray(config.plugins);
+
+test('configs', async (t) => {
+  await t.test('should define configs correctly', () => {
+    assert.ok(configs['recommended']);
+    assert.ok(configs['flat/recommended']);
+
+    assert.ok(isFlatConfig(configs['flat/recommended']));
+    assert.equal(isFlatConfig(configs['recommended']), false);
+  });
+});


### PR DESCRIPTION
Adds support for ESLint flat configs.

For example:

```ts
import {configs} from 'eslint-plugin-depend';

export default [
  {
    files: ['src/**/*.ts'],
    ...configs['flat/recommended']
  }
];
```

Fixes #14 
