### PR TITLE
feat: add replacement for cpx

### DIFF
--- a/src/replacements.ts
+++ b/src/replacements.ts
@@ -38,6 +38,11 @@ export const preferredReplacements: Replacement[] = [
   },
   {
     type: 'documented',
+    moduleName: 'cpx',
+    docPath: 'cpx'
+  },
+  {
+    type: 'documented',
     moduleName: 'is-builtin-module',
     docPath: 'is-builtin-module'
   },


### PR DESCRIPTION
# Summary

Add replacement for `cpx`, similar to what I did in https://github.com/renovatebot/renovate/pull/27507. Closes https://github.com/es-tooling/module-replacements/issues/18.