### PR TITLE
chore: upgrade module-replacements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1667,10 +1667,9 @@
       }
     },
     "node_modules/module-replacements": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/module-replacements/-/module-replacements-2.2.0.tgz",
-      "integrity": "sha512-l+AhjmMWyQL/SYZCt6lKusf0ssJKqdoAg58RhSkmZNBwAzQkBLwFTnzT/dwwkd7HnOwLhf40MTuKKxCAJ+qIPQ==",
-      "license": "MIT"
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/module-replacements/-/module-replacements-2.4.0.tgz",
+      "integrity": "sha512-8bWnDyW68vniWEfINBRnX742waNk1KcULEeAakZ5O46/NLcmdi76ns1kfr642xFbf+QK5Pt2goyY2vUxtS1l3Q=="
     },
     "node_modules/ms": {
       "version": "2.1.2",


### PR DESCRIPTION
Bumps the replacements package so we can pull in new entries.