### PR TITLE
feat: support `@eslint/json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,29 @@ For older legacy projects, add to your `.eslintrc.json`:
 
 Some rules (e.g. `ban-dependencies`) can be used against your `package.json`.
 
-You can achieve this by using `jsonc-eslint-parser`.
+You can achieve this by using `@eslint/json` or `jsonc-eslint-parser`.
 
-For example, in your `.eslintrc.json`:
+For example, with `@eslint/json` and `eslint.config.js`:
+
+```ts
+import depend from 'eslint-plugin-depend';
+import json from '@eslint/json';
+import {defineConfig} from 'eslint/config';
+
+export default defineConfig([
+  {
+    files: ['package.json'],
+    language: 'json/json',
+    plugins: {
+      depend,
+      json
+    },
+    extends: ['depend/flat/recommended'],
+  }
+]);
+```
+
+Or with `jsonc-eslint-parser` and `.eslintrc.json`:
 
 ```json
 {
@@ -64,6 +84,7 @@ For example, in your `.eslintrc.json`:
 ```
 
 Read more at the
+[`@eslint/json` docs](https://github.com/eslint/json) and
 [`jsonc-eslint-parser` docs](https://github.com/ota-meshi/jsonc-eslint-parser).
 
 ## Rules

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.35.0",
+        "@eslint/json": "^0.13.2",
+        "@humanwhocodes/momoa": "^3.3.9",
         "@types/eslint": "^9.6.1",
         "@types/estree": "^1.0.8",
         "@types/node": "^24.4.0",
@@ -284,6 +286,22 @@
         "url": "https://eslint.org/donate"
       }
     },
+    "node_modules/@eslint/json": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@eslint/json/-/json-0.13.2.tgz",
+      "integrity": "sha512-yWLyRE18rHgHXhWigRpiyv1LDPkvWtC6oa7QHXW7YdP6gosJoq7BiLZW2yCs9U7zN7X4U3ZeOJjepA10XAOIMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.15.2",
+        "@eslint/plugin-kit": "^0.3.5",
+        "@humanwhocodes/momoa": "^3.3.9",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@eslint/object-schema": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
@@ -357,6 +375,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/momoa": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-3.3.9.tgz",
+      "integrity": "sha512-LHw6Op4bJb3/3KZgOgwflJx5zY9XOy0NU1NuyUFKGdTwHYmP+PbnQGCYQJ8NVNlulLfQish34b0VuUlLYP3AXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@humanwhocodes/retry": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",
+    "@eslint/json": "^0.13.2",
+    "@humanwhocodes/momoa": "^3.3.9",
     "@types/eslint": "^9.6.1",
     "@types/estree": "^1.0.8",
     "@types/node": "^24.4.0",

--- a/src/test/rules/ban-dependencies_test.ts
+++ b/src/test/rules/ban-dependencies_test.ts
@@ -1,6 +1,7 @@
-import {runClassic} from 'eslint-vitest-rule-tester';
+import {run, runClassic} from 'eslint-vitest-rule-tester';
 import * as tseslintParser from '@typescript-eslint/parser';
 import * as jsonParser from 'jsonc-eslint-parser';
+import eslintJson from '@eslint/json';
 
 import {rule} from '../../rules/ban-dependencies.js';
 import {getMdnUrl, getReplacementsDocUrl} from '../../util/rule-meta.js';
@@ -250,6 +251,68 @@ await runClassic('ban-dependencies', rule, {
       languageOptions: {
         parser: jsonParser
       },
+      errors: [
+        {
+          line: 3,
+          column: 11,
+          messageId: 'documentedReplacement',
+          data: {
+            name: 'npm-run-all',
+            url: getReplacementsDocUrl('npm-run-all')
+          }
+        }
+      ]
+    }
+  ]
+});
+
+// Test using `@eslint/json` plugin
+run({
+  name: 'ban-dependencies-json',
+  configs: [
+    {
+      files: ['**/*.json'],
+      language: 'json/json',
+      plugins: {
+        json: eslintJson
+      }
+    }
+  ],
+  rule,
+  valid: [
+    {
+      code: `{
+        "dependencies": {
+          "unknown-module": "^1.0.0"
+        }
+      }`,
+      filename: 'package.json'
+    },
+    {
+      code: `{
+        "dependencies": {
+          "npm-run-all": "^1.0.0"
+        }
+      }`,
+      filename: 'not-a-package.json'
+    },
+    {
+      code: `{
+        "not-dependencies": {
+          "some-other-nonsense": 123
+        }
+      }`,
+      filename: 'package.json'
+    }
+  ],
+  invalid: [
+    {
+      code: `{
+        "dependencies": {
+          "npm-run-all": "^1.0.0"
+        }
+      }`,
+      filename: 'package.json',
       errors: [
         {
           line: 3,

--- a/src/util/imports.ts
+++ b/src/util/imports.ts
@@ -155,7 +155,7 @@ export function createPackageJsonListener(
   callback: ImportListenerCallback
 ): Rule.RuleListener {
   return {
-    // Support with `@eslint/json`
+    // Support for `@eslint/json`
     'Document > Object > Member': (node: MemberNode) => {
       if (
         node.name.type === 'String' &&
@@ -173,7 +173,7 @@ export function createPackageJsonListener(
         }
       }
     },
-    // Support with `jsonc-eslint-parser`
+    // Support for `jsonc-eslint-parser`
     'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty': (
       astNode: Rule.Node
     ) => {

--- a/src/util/imports.ts
+++ b/src/util/imports.ts
@@ -2,6 +2,7 @@ import type {Rule} from 'eslint';
 import {TSESTree} from '@typescript-eslint/typescript-estree';
 import {closestPackageSatisfiesNodeVersion} from './package-json.js';
 import {getMdnUrl, getReplacementsDocUrl} from './rule-meta.js';
+import type {MemberNode} from '@humanwhocodes/momoa';
 import type {AST as JsonESTree} from 'jsonc-eslint-parser';
 import type {ModuleReplacement} from 'module-replacements';
 
@@ -154,6 +155,25 @@ export function createPackageJsonListener(
   callback: ImportListenerCallback
 ): Rule.RuleListener {
   return {
+    // Support with `@eslint/json`
+    'Document > Object > Member': (node: MemberNode) => {
+      if (
+        node.name.type === 'String' &&
+        dependencyKeys.includes(node.name.value) &&
+        node.value.type === 'Object'
+      ) {
+        for (const member of node.value.members) {
+          if (member.name.type === 'String') {
+            callback(
+              context,
+              member as unknown as Rule.Node,
+              member.name.value
+            );
+          }
+        }
+      }
+    },
+    // Support with `jsonc-eslint-parser`
     'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty': (
       astNode: Rule.Node
     ) => {


### PR DESCRIPTION
Adds support for `@eslint/json` using its AST query syntax. `@eslint/json` is the officially supported way to process json files.