### PR TITLE
fix: mark type import for typescript-estree

### DIFF
--- a/src/util/imports.ts
+++ b/src/util/imports.ts
@@ -1,5 +1,5 @@
 import type {Rule} from 'eslint';
-import {TSESTree} from '@typescript-eslint/typescript-estree';
+import type {TSESTree} from '@typescript-eslint/typescript-estree';
 import {closestPackageSatisfiesNodeVersion} from './package-json.js';
 import {getMdnUrl, getReplacementsDocUrl} from './rule-meta.js';
 import type {MemberNode} from '@humanwhocodes/momoa';


### PR DESCRIPTION
#52 added `verbatimModuleSyntax": true` to the tsconfig and it missed marking a type import from `@typescript-eslint/typescript-estree` as a type. Resulting in `@typescript-eslint/typescript-estree` being preserved in JS and fails to import as it's not a dependency.